### PR TITLE
Update composer.json to require newer sentry version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/support": "~5",
         "illuminate/queue": "~5",
         "monolog/monolog": "~1.11",
-        "sentry/sentry": "~0.19"
+        "sentry/sentry": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
This prevents this warning in the sentry dashboard: "This event was reported with an old version of the php SDK."
