### PR TITLE
Match signature of Client::send to Sentry 1.0.0

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -62,7 +62,7 @@ class Client extends Raven_Client
     /**
      * {@inheritdoc}
      */
-    public function send($data)
+    public function send(&$data)
     {
         $this->eventId = array_get($data, 'event_id');
 


### PR DESCRIPTION
In Sentry/Raven 1.0.0 (specifically commit b2e3d65e5b510114c194386dcc0056585ca651fe) the signature of `Client::send` changed to allow data mutation in send_callback.

The corresponding method in this package needs to change to avoid an exception:

    Declaration of Twine\Raven\Client::send($data) should be compatible with Raven_Client::send(&$data)