### PR TITLE
Add support for Laravel 5.4

### DIFF
--- a/src/Providers/AbstractServiceProvider.php
+++ b/src/Providers/AbstractServiceProvider.php
@@ -16,7 +16,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app[Client::class] = $this->app->share(function ($app) {
+        $this->app->singleton(Client::class, function ($app) {
             return new Client($app['config']['raven'], $app['queue'], $app->environment());
         });
 
@@ -42,7 +42,7 @@ abstract class AbstractServiceProvider extends ServiceProvider
     {
         $handler = new RavenHandler($this->app[Client::class], $this->app['config']['raven.level']);
         $handler->setFormatter(new LineFormatter('%message%'));
-        
+
         // Add processors
         $processors = $this->app['config']['raven.monolog.processors'] ?: [];
 


### PR DESCRIPTION
From the [5.3 to 5.4 documentation](https://laravel.com/docs/5.4/upgrade)

> The share method has been removed from the container. This was a legacy method that has not been documented in several years. If you are using this method, you should begin using the  singleton method instead:

This PR changes the `share` method call in the `AbstractServiceProvider` to `singleton` to allow this package to work with Laravel 5.4.
